### PR TITLE
custom plugin

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM java:8-jre
 MAINTAINER Sergey Novikov <snov@snov.me>
 
+RUN apt-get update && apt-get install jq
 RUN UNATTENDED=true bash -c "$(curl -sSL https://download.newrelic.com/npi/release/install-npi-linux-debian-x64.sh)"
 
 WORKDIR /root/newrelic-npi
@@ -9,4 +10,6 @@ RUN ./npi fetch me.snov.newrelic-elasticsearch -y
 COPY plugin.json ./plugin.json
 COPY start.sh ./start.sh
 
-CMD ./start.sh
+CMD bash start.sh
+
+VOLUME "/nre-config"

--- a/README.md
+++ b/README.md
@@ -1,17 +1,55 @@
 # newrelic-elasticsearch
-
+ 
 Docker container for [New Relic Elasticsearch plugin](https://github.com/s12v/newrelic-elasticsearch)
 
+# Usage
 
-## Usage
+You can run elasticsearch command simply:
+```
+$ docker run --name elasticsearch -d elasticsearch
+```
+than you need to attach the monitor daemon:
+```
+$ docker run -d --link elasticsearch -e NEW_RELIC_LICENSE_KEY=<YOUR_KEY> s12v/newrelic-elasticsearch 
+```
+This image comes with the default ```plugin.json``` configuration file:
+```
+{
+  "agents": [
+    {
+      "host" : "elasticsearch",
+      "port" : 9200,
+      "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it"
+    }
+  ]
+}
+```
 
-Example `docker-compose.yml` defines a cluster with 3 elasticsearch nodes and 1 New Relic monitoring container:
+if you want to provide your own configuration file, you can do so via a volume mounted at /nre-config:
 
-```yml
+```
+$ docker run -d --link elasticsearch -e NEW_RELIC_LICENSE_KEY=<YOUR_KEY> -v /dir/with/config:/nre-config s12v/newrelic-elasticsearch 
+```
+
+if you want to access elasticsearch instances that are not linked, simply use the hosts network:
+```
+$ docker run -d -e NEW_RELIC_LICENSE_KEY=<YOUR_KEY> -v /dir/with/config:/nre-config --net=host s12v/newrelic-elasticsearch
+```
+
+you can also change the default reconnect attempts from 10 to whatever you like,
+by changing the ```ES_RECONNECTS``` environment variable.
+
+# usage with compose
+
+Example ```docker-compose.yml``` defines a cluster with 3 elasticsearch nodes and 1 New Relic monitoring container:
+```
 es1:
   image: elasticsearch
   ports:
   - "9200:9200"
+  links:
+  - es2
+  - es3
 es2:
   image: elasticsearch
 es3:
@@ -24,4 +62,4 @@ newrelic:
     - NEW_RELIC_LICENSE_KEY=itsasecret
 ```
 
-Change your license key and run `docker-compose up`.
+Change your license key and run ```docker-compose up -d```.

--- a/plugin.json
+++ b/plugin.json
@@ -1,9 +1,10 @@
 {
+
   "agents": [
     {
-      "host" : "%HOST%",
-      "port" : %PORT%,
-      "_name": "%NAME%"
+      "host" : "elasticsearch",
+      "port" : 9200,
+      "_name": "Optional. By default loaded from elasticsearch. Rename to 'name' if you need to customize it"
     }
   ]
 }

--- a/start.sh
+++ b/start.sh
@@ -1,17 +1,21 @@
 #!/bin/sh
+set -e
 
-name=${ES_NAME:-docker}
-host=${ES_HOST:-elasticsearch}
-port=${ES_PORT:-9200}
 reconnects=${ES_RECONNECTS:-10}
+
+plugin_path="/nre-config/plugin.json"
+if ! [ -f $plugin_path ]; then
+  plugin_path="plugin.json"
+fi
+
+name=`cat $plugin_path | jq -r '.agents[].name // "elasticsearch"'`
+host=`cat $plugin_path | jq -r '.agents[].host // "elasticsearch"'`
+port=`cat $plugin_path | jq -r '.agents[].port // 9200'`
 
 ./npi config set license_key $NEW_RELIC_LICENSE_KEY
 ./npi prepare me.snov.newrelic-elasticsearch -n -q
 
-sed -i "s/%HOST%/$host/g" plugin.json
-sed -i "s/%PORT%/$port/g" plugin.json
-sed -i "s/%NAME%/$name/g" plugin.json
-cp plugin.json `find . -path './plugins/me.snov.newrelic-elasticsearch/*/config/plugin.json'`
+cp $plugin_path `find . -path './plugins/me.snov.newrelic-elasticsearch/*/config/plugin.json'`
 
 for i in `seq 1 $reconnects`
 do
@@ -19,6 +23,7 @@ do
 	if curl --silent "$host:$port" > /dev/null
 	then
  		echo "OK"
+    echo "find '$name' instance under the plugins tab at https://rpm.newrelic.com"
 		break
  	fi
 	echo "NOT AVAILABLE"


### PR DESCRIPTION
- added an option to use a custom plugin.json file
    that sits in a directory mounted at /nre-config
- ES_HOST/ES_PORT won't work if the linked container isn't named es
    instead, updated the start script to extract the host/port/name
    from the config file and fallback to default values if they're missing
